### PR TITLE
propagates error reasons on rejects from shouldResolve

### DIFF
--- a/lib/promise-matchers.js
+++ b/lib/promise-matchers.js
@@ -39,7 +39,7 @@ function toResolve() {
     compare: function(promise, done) {
       ensureDone(done);
       promise.then(done, function(error) {
-        done.fail(new NestedError('Promise was rejected', error));
+        done.fail(error);
       });
 
       return { pass: true };

--- a/spec/promise-matchers.spec.js
+++ b/spec/promise-matchers.spec.js
@@ -39,15 +39,14 @@ describe('PromiseMatchers', function() {
     });
 
     it('fails on a rejected promise', function(done) {
-      var nestedError = new Error('my nested error');
+      var error = new Error('error reason');
       var promise = new Promise(function(resolve, reject) {
-        reject(nestedError);
+        reject(error);
       });
 
       spyOn(done, 'fail').and.callFake(function(error) {
-        expect(error instanceof NestedError).toBe(true);
-        expect(error.nested).toBe(nestedError);
-        expect(error.message).toBe('Promise was rejected');
+        expect(error instanceof Error).toBe(true);
+        expect(error.message).toBe('error reason');
         done();
       });
 


### PR DESCRIPTION
Proposed fix to issue #11.

This removes nestedError from `shouldResolve`. Not sure if that is a bad thing. Is the error really nested?